### PR TITLE
Backport SPV_INTEL_predicated_io  to 1.4.350.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,20 @@ package:
 source:
   - url: https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/vulkan-sdk-{{ version }}.tar.gz
     sha256: 9905d9341f20388adb852c77dd982f2c4d539fd68e6c1f1bcebf034715f2d1d5
+    patches:
+      # Backport SPV_INTEL_predicated_io: adds OpPredicatedLoadINTEL /
+      # OpPredicatedStoreINTEL (6258/6259), required to build
+      # SPIRV-LLVM-Translator 16.0.25.  The PR was authored directly on top of
+      # vulkan-sdk-1.4.350.0, so the patch applies cleanly.
+      # Pull request: https://github.com/KhronosGroup/SPIRV-Headers/pull/585
+      # Merged to main as commit b8a32968473ce852a809b9de5f04f02a5a9dfa78:
+      # https://github.com/KhronosGroup/SPIRV-Headers/commit/b8a32968473ce852a809b9de5f04f02a5a9dfa78
+      # Lives on the main branch: https://github.com/KhronosGroup/SPIRV-Headers/tree/main
+      # Drop this patch once a vulkan-sdk-* release includes the extension.
+      - patches/0001-SPV_INTEL_predicated_io.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/patches/0001-SPV_INTEL_predicated_io.patch
+++ b/recipe/patches/0001-SPV_INTEL_predicated_io.patch
@@ -1,0 +1,340 @@
+From b8a32968473ce852a809b9de5f04f02a5a9dfa78 Mon Sep 17 00:00:00 2001
+From: Yury Plyakhin <yury.plyakhin@intel.com>
+Date: Wed, 29 Apr 2026 07:52:53 -0700
+Subject: [PATCH] grammar and header changes for SPV_INTEL_predicated_io (#585)
+
+---
+ include/spirv/unified1/spirv.bf               |  3 ++
+ .../spirv/unified1/spirv.core.grammar.json    | 34 +++++++++++++++++++
+ include/spirv/unified1/spirv.cs               |  3 ++
+ include/spirv/unified1/spirv.h                |  8 +++++
+ include/spirv/unified1/spirv.hpp              |  8 +++++
+ include/spirv/unified1/spirv.hpp11            |  8 +++++
+ include/spirv/unified1/spirv.json             |  3 ++
+ include/spirv/unified1/spirv.lua              |  3 ++
+ include/spirv/unified1/spirv.py               |  3 ++
+ include/spirv/unified1/spv.d                  |  3 ++
+ 10 files changed, 76 insertions(+)
+
+diff --git a/include/spirv/unified1/spirv.bf b/include/spirv/unified1/spirv.bf
+index b705259..0fd8703 100644
+--- a/include/spirv/unified1/spirv.bf
++++ b/include/spirv/unified1/spirv.bf
+@@ -1426,6 +1426,7 @@ namespace Spv
+             UntypedVariableLengthArrayINTEL = 6243,
+             SpecConditionalINTEL = 6245,
+             FunctionVariantsINTEL = 6246,
++            PredicatedIOINTEL = 6257,
+             GroupUniformArithmeticKHR = 6400,
+             TensorFloat32RoundingINTEL = 6425,
+             MaskedGatherScatterINTEL = 6427,
+@@ -2694,6 +2695,8 @@ namespace Spv
+             OpSpecConstantArchitectureINTEL = 6252,
+             OpSpecConstantCapabilitiesINTEL = 6253,
+             OpConditionalCopyObjectINTEL = 6254,
++            OpPredicatedLoadINTEL = 6258,
++            OpPredicatedStoreINTEL = 6259,
+             OpGroupIMulKHR = 6401,
+             OpGroupFMulKHR = 6402,
+             OpGroupBitwiseAndKHR = 6403,
+diff --git a/include/spirv/unified1/spirv.core.grammar.json b/include/spirv/unified1/spirv.core.grammar.json
+index 22f5fe9..0a282c5 100644
+--- a/include/spirv/unified1/spirv.core.grammar.json
++++ b/include/spirv/unified1/spirv.core.grammar.json
+@@ -11598,6 +11598,34 @@
+       "provisional" : true,
+       "version" : "None"
+     },
++    {
++      "opname" : "OpPredicatedLoadINTEL",
++      "class"  : "Memory",
++      "opcode" : 6258,
++      "operands" : [
++        { "kind" : "IdResultType" },
++        { "kind" : "IdResult" },
++        { "kind" : "IdRef",                          "name" : "Pointer" },
++        { "kind" : "IdRef",                          "name" : "Predicate" },
++        { "kind" : "IdRef",                          "name" : "Default Value" },
++        { "kind" : "MemoryAccess", "quantifier" : "?" }
++      ],
++      "capabilities" : [ "PredicatedIOINTEL" ],
++      "version" : "None"
++    },
++    {
++      "opname" : "OpPredicatedStoreINTEL",
++      "class"  : "Memory",
++      "opcode" : 6259,
++      "operands" : [
++        { "kind" : "IdRef",                          "name" : "Pointer" },
++        { "kind" : "IdRef",                          "name" : "Object" },
++        { "kind" : "IdRef",                          "name" : "Predicate" },
++        { "kind" : "MemoryAccess", "quantifier" : "?" }
++      ],
++      "capabilities" : [ "PredicatedIOINTEL" ],
++      "version" : "None"
++    },
+     {
+       "opname" : "OpGroupIMulKHR",
+       "class"  : "Group",
+@@ -18659,6 +18687,12 @@
+           "provisional" : true,
+           "version": "None"
+         },
++        {
++          "enumerant" : "PredicatedIOINTEL",
++          "value" : 6257,
++          "extensions" : [ "SPV_INTEL_predicated_io" ],
++          "version" : "None"
++        },
+         {
+           "enumerant" : "GroupUniformArithmeticKHR",
+           "value" : 6400,
+diff --git a/include/spirv/unified1/spirv.cs b/include/spirv/unified1/spirv.cs
+index 2f8c1ff..375dd0b 100644
+--- a/include/spirv/unified1/spirv.cs
++++ b/include/spirv/unified1/spirv.cs
+@@ -1425,6 +1425,7 @@ namespace Spv
+             UntypedVariableLengthArrayINTEL = 6243,
+             SpecConditionalINTEL = 6245,
+             FunctionVariantsINTEL = 6246,
++            PredicatedIOINTEL = 6257,
+             GroupUniformArithmeticKHR = 6400,
+             TensorFloat32RoundingINTEL = 6425,
+             MaskedGatherScatterINTEL = 6427,
+@@ -2693,6 +2694,8 @@ namespace Spv
+             OpSpecConstantArchitectureINTEL = 6252,
+             OpSpecConstantCapabilitiesINTEL = 6253,
+             OpConditionalCopyObjectINTEL = 6254,
++            OpPredicatedLoadINTEL = 6258,
++            OpPredicatedStoreINTEL = 6259,
+             OpGroupIMulKHR = 6401,
+             OpGroupFMulKHR = 6402,
+             OpGroupBitwiseAndKHR = 6403,
+diff --git a/include/spirv/unified1/spirv.h b/include/spirv/unified1/spirv.h
+index d00cf0f..9233ff0 100644
+--- a/include/spirv/unified1/spirv.h
++++ b/include/spirv/unified1/spirv.h
+@@ -1396,6 +1396,7 @@ typedef enum SpvCapability_ {
+     SpvCapabilityUntypedVariableLengthArrayINTEL = 6243,
+     SpvCapabilitySpecConditionalINTEL = 6245,
+     SpvCapabilityFunctionVariantsINTEL = 6246,
++    SpvCapabilityPredicatedIOINTEL = 6257,
+     SpvCapabilityGroupUniformArithmeticKHR = 6400,
+     SpvCapabilityTensorFloat32RoundingINTEL = 6425,
+     SpvCapabilityMaskedGatherScatterINTEL = 6427,
+@@ -2628,6 +2629,8 @@ typedef enum SpvOp_ {
+     SpvOpSpecConstantArchitectureINTEL = 6252,
+     SpvOpSpecConstantCapabilitiesINTEL = 6253,
+     SpvOpConditionalCopyObjectINTEL = 6254,
++    SpvOpPredicatedLoadINTEL = 6258,
++    SpvOpPredicatedStoreINTEL = 6259,
+     SpvOpGroupIMulKHR = 6401,
+     SpvOpGroupFMulKHR = 6402,
+     SpvOpGroupBitwiseAndKHR = 6403,
+@@ -3510,6 +3513,8 @@ inline void SpvHasResultAndType(SpvOp opcode, bool *hasResult, bool *hasResultTy
+     case SpvOpSpecConstantArchitectureINTEL: *hasResult = true; *hasResultType = true; break;
+     case SpvOpSpecConstantCapabilitiesINTEL: *hasResult = true; *hasResultType = true; break;
+     case SpvOpConditionalCopyObjectINTEL: *hasResult = true; *hasResultType = true; break;
++    case SpvOpPredicatedLoadINTEL: *hasResult = true; *hasResultType = true; break;
++    case SpvOpPredicatedStoreINTEL: *hasResult = false; *hasResultType = false; break;
+     case SpvOpGroupIMulKHR: *hasResult = true; *hasResultType = true; break;
+     case SpvOpGroupFMulKHR: *hasResult = true; *hasResultType = true; break;
+     case SpvOpGroupBitwiseAndKHR: *hasResult = true; *hasResultType = true; break;
+@@ -4517,6 +4522,7 @@ inline const char* SpvCapabilityToString(SpvCapability value) {
+     case SpvCapabilityUntypedVariableLengthArrayINTEL: return "UntypedVariableLengthArrayINTEL";
+     case SpvCapabilitySpecConditionalINTEL: return "SpecConditionalINTEL";
+     case SpvCapabilityFunctionVariantsINTEL: return "FunctionVariantsINTEL";
++    case SpvCapabilityPredicatedIOINTEL: return "PredicatedIOINTEL";
+     case SpvCapabilityGroupUniformArithmeticKHR: return "GroupUniformArithmeticKHR";
+     case SpvCapabilityTensorFloat32RoundingINTEL: return "TensorFloat32RoundingINTEL";
+     case SpvCapabilityMaskedGatherScatterINTEL: return "MaskedGatherScatterINTEL";
+@@ -5575,6 +5581,8 @@ inline const char* SpvOpToString(SpvOp value) {
+     case SpvOpSpecConstantArchitectureINTEL: return "OpSpecConstantArchitectureINTEL";
+     case SpvOpSpecConstantCapabilitiesINTEL: return "OpSpecConstantCapabilitiesINTEL";
+     case SpvOpConditionalCopyObjectINTEL: return "OpConditionalCopyObjectINTEL";
++    case SpvOpPredicatedLoadINTEL: return "OpPredicatedLoadINTEL";
++    case SpvOpPredicatedStoreINTEL: return "OpPredicatedStoreINTEL";
+     case SpvOpGroupIMulKHR: return "OpGroupIMulKHR";
+     case SpvOpGroupFMulKHR: return "OpGroupFMulKHR";
+     case SpvOpGroupBitwiseAndKHR: return "OpGroupBitwiseAndKHR";
+diff --git a/include/spirv/unified1/spirv.hpp b/include/spirv/unified1/spirv.hpp
+index 462c3f6..055086c 100644
+--- a/include/spirv/unified1/spirv.hpp
++++ b/include/spirv/unified1/spirv.hpp
+@@ -1392,6 +1392,7 @@ enum Capability {
+     CapabilityUntypedVariableLengthArrayINTEL = 6243,
+     CapabilitySpecConditionalINTEL = 6245,
+     CapabilityFunctionVariantsINTEL = 6246,
++    CapabilityPredicatedIOINTEL = 6257,
+     CapabilityGroupUniformArithmeticKHR = 6400,
+     CapabilityTensorFloat32RoundingINTEL = 6425,
+     CapabilityMaskedGatherScatterINTEL = 6427,
+@@ -2624,6 +2625,8 @@ enum Op {
+     OpSpecConstantArchitectureINTEL = 6252,
+     OpSpecConstantCapabilitiesINTEL = 6253,
+     OpConditionalCopyObjectINTEL = 6254,
++    OpPredicatedLoadINTEL = 6258,
++    OpPredicatedStoreINTEL = 6259,
+     OpGroupIMulKHR = 6401,
+     OpGroupFMulKHR = 6402,
+     OpGroupBitwiseAndKHR = 6403,
+@@ -3506,6 +3509,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
+     case OpSpecConstantArchitectureINTEL: *hasResult = true; *hasResultType = true; break;
+     case OpSpecConstantCapabilitiesINTEL: *hasResult = true; *hasResultType = true; break;
+     case OpConditionalCopyObjectINTEL: *hasResult = true; *hasResultType = true; break;
++    case OpPredicatedLoadINTEL: *hasResult = true; *hasResultType = true; break;
++    case OpPredicatedStoreINTEL: *hasResult = false; *hasResultType = false; break;
+     case OpGroupIMulKHR: *hasResult = true; *hasResultType = true; break;
+     case OpGroupFMulKHR: *hasResult = true; *hasResultType = true; break;
+     case OpGroupBitwiseAndKHR: *hasResult = true; *hasResultType = true; break;
+@@ -4513,6 +4518,7 @@ inline const char* CapabilityToString(Capability value) {
+     case CapabilityUntypedVariableLengthArrayINTEL: return "UntypedVariableLengthArrayINTEL";
+     case CapabilitySpecConditionalINTEL: return "SpecConditionalINTEL";
+     case CapabilityFunctionVariantsINTEL: return "FunctionVariantsINTEL";
++    case CapabilityPredicatedIOINTEL: return "PredicatedIOINTEL";
+     case CapabilityGroupUniformArithmeticKHR: return "GroupUniformArithmeticKHR";
+     case CapabilityTensorFloat32RoundingINTEL: return "TensorFloat32RoundingINTEL";
+     case CapabilityMaskedGatherScatterINTEL: return "MaskedGatherScatterINTEL";
+@@ -5571,6 +5577,8 @@ inline const char* OpToString(Op value) {
+     case OpSpecConstantArchitectureINTEL: return "OpSpecConstantArchitectureINTEL";
+     case OpSpecConstantCapabilitiesINTEL: return "OpSpecConstantCapabilitiesINTEL";
+     case OpConditionalCopyObjectINTEL: return "OpConditionalCopyObjectINTEL";
++    case OpPredicatedLoadINTEL: return "OpPredicatedLoadINTEL";
++    case OpPredicatedStoreINTEL: return "OpPredicatedStoreINTEL";
+     case OpGroupIMulKHR: return "OpGroupIMulKHR";
+     case OpGroupFMulKHR: return "OpGroupFMulKHR";
+     case OpGroupBitwiseAndKHR: return "OpGroupBitwiseAndKHR";
+diff --git a/include/spirv/unified1/spirv.hpp11 b/include/spirv/unified1/spirv.hpp11
+index 41ebe91..0d85dfe 100644
+--- a/include/spirv/unified1/spirv.hpp11
++++ b/include/spirv/unified1/spirv.hpp11
+@@ -1392,6 +1392,7 @@ enum class Capability : unsigned {
+     UntypedVariableLengthArrayINTEL = 6243,
+     SpecConditionalINTEL = 6245,
+     FunctionVariantsINTEL = 6246,
++    PredicatedIOINTEL = 6257,
+     GroupUniformArithmeticKHR = 6400,
+     TensorFloat32RoundingINTEL = 6425,
+     MaskedGatherScatterINTEL = 6427,
+@@ -2624,6 +2625,8 @@ enum class Op : unsigned {
+     OpSpecConstantArchitectureINTEL = 6252,
+     OpSpecConstantCapabilitiesINTEL = 6253,
+     OpConditionalCopyObjectINTEL = 6254,
++    OpPredicatedLoadINTEL = 6258,
++    OpPredicatedStoreINTEL = 6259,
+     OpGroupIMulKHR = 6401,
+     OpGroupFMulKHR = 6402,
+     OpGroupBitwiseAndKHR = 6403,
+@@ -3506,6 +3509,8 @@ inline void HasResultAndType(Op opcode, bool *hasResult, bool *hasResultType) {
+     case Op::OpSpecConstantArchitectureINTEL: *hasResult = true; *hasResultType = true; break;
+     case Op::OpSpecConstantCapabilitiesINTEL: *hasResult = true; *hasResultType = true; break;
+     case Op::OpConditionalCopyObjectINTEL: *hasResult = true; *hasResultType = true; break;
++    case Op::OpPredicatedLoadINTEL: *hasResult = true; *hasResultType = true; break;
++    case Op::OpPredicatedStoreINTEL: *hasResult = false; *hasResultType = false; break;
+     case Op::OpGroupIMulKHR: *hasResult = true; *hasResultType = true; break;
+     case Op::OpGroupFMulKHR: *hasResult = true; *hasResultType = true; break;
+     case Op::OpGroupBitwiseAndKHR: *hasResult = true; *hasResultType = true; break;
+@@ -4513,6 +4518,7 @@ inline const char* CapabilityToString(Capability value) {
+     case Capability::UntypedVariableLengthArrayINTEL: return "UntypedVariableLengthArrayINTEL";
+     case Capability::SpecConditionalINTEL: return "SpecConditionalINTEL";
+     case Capability::FunctionVariantsINTEL: return "FunctionVariantsINTEL";
++    case Capability::PredicatedIOINTEL: return "PredicatedIOINTEL";
+     case Capability::GroupUniformArithmeticKHR: return "GroupUniformArithmeticKHR";
+     case Capability::TensorFloat32RoundingINTEL: return "TensorFloat32RoundingINTEL";
+     case Capability::MaskedGatherScatterINTEL: return "MaskedGatherScatterINTEL";
+@@ -5571,6 +5577,8 @@ inline const char* OpToString(Op value) {
+     case Op::OpSpecConstantArchitectureINTEL: return "OpSpecConstantArchitectureINTEL";
+     case Op::OpSpecConstantCapabilitiesINTEL: return "OpSpecConstantCapabilitiesINTEL";
+     case Op::OpConditionalCopyObjectINTEL: return "OpConditionalCopyObjectINTEL";
++    case Op::OpPredicatedLoadINTEL: return "OpPredicatedLoadINTEL";
++    case Op::OpPredicatedStoreINTEL: return "OpPredicatedStoreINTEL";
+     case Op::OpGroupIMulKHR: return "OpGroupIMulKHR";
+     case Op::OpGroupFMulKHR: return "OpGroupFMulKHR";
+     case Op::OpGroupBitwiseAndKHR: return "OpGroupBitwiseAndKHR";
+diff --git a/include/spirv/unified1/spirv.json b/include/spirv/unified1/spirv.json
+index 0a200b2..ec778af 100644
+--- a/include/spirv/unified1/spirv.json
++++ b/include/spirv/unified1/spirv.json
+@@ -1358,6 +1358,7 @@
+                     "UntypedVariableLengthArrayINTEL": 6243,
+                     "SpecConditionalINTEL": 6245,
+                     "FunctionVariantsINTEL": 6246,
++                    "PredicatedIOINTEL": 6257,
+                     "GroupUniformArithmeticKHR": 6400,
+                     "TensorFloat32RoundingINTEL": 6425,
+                     "MaskedGatherScatterINTEL": 6427,
+@@ -2595,6 +2596,8 @@
+                     "OpSpecConstantArchitectureINTEL": 6252,
+                     "OpSpecConstantCapabilitiesINTEL": 6253,
+                     "OpConditionalCopyObjectINTEL": 6254,
++                    "OpPredicatedLoadINTEL": 6258,
++                    "OpPredicatedStoreINTEL": 6259,
+                     "OpGroupIMulKHR": 6401,
+                     "OpGroupFMulKHR": 6402,
+                     "OpGroupBitwiseAndKHR": 6403,
+diff --git a/include/spirv/unified1/spirv.lua b/include/spirv/unified1/spirv.lua
+index e612025..b883dd8 100644
+--- a/include/spirv/unified1/spirv.lua
++++ b/include/spirv/unified1/spirv.lua
+@@ -1383,6 +1383,7 @@ spv = {
+         UntypedVariableLengthArrayINTEL = 6243,
+         SpecConditionalINTEL = 6245,
+         FunctionVariantsINTEL = 6246,
++        PredicatedIOINTEL = 6257,
+         GroupUniformArithmeticKHR = 6400,
+         TensorFloat32RoundingINTEL = 6425,
+         MaskedGatherScatterINTEL = 6427,
+@@ -2615,6 +2616,8 @@ spv = {
+         OpSpecConstantArchitectureINTEL = 6252,
+         OpSpecConstantCapabilitiesINTEL = 6253,
+         OpConditionalCopyObjectINTEL = 6254,
++        OpPredicatedLoadINTEL = 6258,
++        OpPredicatedStoreINTEL = 6259,
+         OpGroupIMulKHR = 6401,
+         OpGroupFMulKHR = 6402,
+         OpGroupBitwiseAndKHR = 6403,
+diff --git a/include/spirv/unified1/spirv.py b/include/spirv/unified1/spirv.py
+index 1085498..590ee22 100644
+--- a/include/spirv/unified1/spirv.py
++++ b/include/spirv/unified1/spirv.py
+@@ -1354,6 +1354,7 @@ spv = {
+         'UntypedVariableLengthArrayINTEL' : 6243,
+         'SpecConditionalINTEL' : 6245,
+         'FunctionVariantsINTEL' : 6246,
++        'PredicatedIOINTEL' : 6257,
+         'GroupUniformArithmeticKHR' : 6400,
+         'TensorFloat32RoundingINTEL' : 6425,
+         'MaskedGatherScatterINTEL' : 6427,
+@@ -2558,6 +2559,8 @@ spv = {
+         'OpSpecConstantArchitectureINTEL' : 6252,
+         'OpSpecConstantCapabilitiesINTEL' : 6253,
+         'OpConditionalCopyObjectINTEL' : 6254,
++        'OpPredicatedLoadINTEL' : 6258,
++        'OpPredicatedStoreINTEL' : 6259,
+         'OpGroupIMulKHR' : 6401,
+         'OpGroupFMulKHR' : 6402,
+         'OpGroupBitwiseAndKHR' : 6403,
+diff --git a/include/spirv/unified1/spv.d b/include/spirv/unified1/spv.d
+index c9cde5d..0323867 100644
+--- a/include/spirv/unified1/spv.d
++++ b/include/spirv/unified1/spv.d
+@@ -1428,6 +1428,7 @@ enum Capability : uint
+     UntypedVariableLengthArrayINTEL = 6243,
+     SpecConditionalINTEL = 6245,
+     FunctionVariantsINTEL = 6246,
++    PredicatedIOINTEL = 6257,
+     GroupUniformArithmeticKHR = 6400,
+     TensorFloat32RoundingINTEL = 6425,
+     MaskedGatherScatterINTEL = 6427,
+@@ -2696,6 +2697,8 @@ enum Op : uint
+     OpSpecConstantArchitectureINTEL = 6252,
+     OpSpecConstantCapabilitiesINTEL = 6253,
+     OpConditionalCopyObjectINTEL = 6254,
++    OpPredicatedLoadINTEL = 6258,
++    OpPredicatedStoreINTEL = 6259,
+     OpGroupIMulKHR = 6401,
+     OpGroupFMulKHR = 6402,
+     OpGroupBitwiseAndKHR = 6403,
+-- 
+2.54.0
+


### PR DESCRIPTION
Needed for https://github.com/conda-forge/llvm-spirv-feedstock/pull/65
<details><summary>Claude's draft</summary>

SPIRV-LLVM-Translator 16.0.25 references SPV_INTEL_predicated_io opcodes (OpPredicatedLoadINTEL/StoreINTEL = 6258/6259) which are only on SPIRV-Headers `main` -- the latest release tag (vulkan-sdk-1.4.350.0) does not have them. This snapshots main (commit 1e770e7, 17 commits past 1.4.350.0) so dependents that need predicated_io can build.

SNAPSHOT / placeholder version 1.4.351.0 -- replace the source with the next vulkan-sdk-* release tag (and the version with its number) once Khronos tags a release that includes SPV_INTEL_predicated_io.

NOTE: spirv-tools run-constrains spirv-headers to an exact version, so bumping spirv-headers must be coordinated with a spirv-tools rebuild.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Resume this Claude session:
```
claude --resume 8959e104-fade-4e06-a903-ec84f609fa1c
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
